### PR TITLE
Adds a 'tall-toasts:assets' command to help with #31 

### DIFF
--- a/src/Console/CopyAssetsToPublicFolder.php
+++ b/src/Console/CopyAssetsToPublicFolder.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Usernotnull\Toast\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+
+class CopyAssetsToPublicFolder extends Command
+{
+    /**
+     * @var string
+     */
+    protected $signature = 'tall-toast:assets';
+
+    /**
+     * @var string
+     */
+    protected $description = 'Copy tall toasts assets to the public folder.';
+
+    /**
+     * Copies the files only if necessary.
+     *
+     * @return int
+     */
+    public function handle() : int
+    {
+        $vendorToastFile = __DIR__ . '/../../dist/js/tall-toasts.js';
+        $vendorToastMap = __DIR__ . '/../../dist/js/tall-toasts.js.map';
+
+        $publicToastFile = public_path('/toast/tall-toasts.js');
+        $publicToastMap = public_path('/toast/tall-toasts.js.map');
+
+        if($this->fileExists(public_path('toast/tall-toasts.js'))){
+            if($this->fileIsSame($vendorToastFile, $publicToastFile)){
+                $this->info('Tall Toasts Javascript does not need to be copied.');
+                return Command::SUCCESS;
+            }
+        }
+
+        $this->copyFile($vendorToastFile, $publicToastFile);
+        $this->copyFile($vendorToastMap, $publicToastMap);
+
+        $this->info('Copied Tall Toasts assets to public/toast/');
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Checks if a file exists.
+     * @param string $fileName
+     * @return bool
+     */
+    private function fileExists(string $fileName) : bool
+    {
+        return File::exists($fileName);
+    }
+
+    /**
+     * Checks if two file's contents are the same.
+     * @param string $originalFile
+     * @param string $publicFile
+     * @return bool
+     */
+    private function fileIsSame(string $originalFile, string $publicFile) : bool
+    {
+        return file_get_contents($originalFile) === file_get_contents($publicFile);
+    }
+
+    /**
+     * Copies a file to a new location.
+     * @param string $fileFrom
+     * @param string $fileTo
+     * @return bool
+     */
+    private function copyFile(string $fileFrom, string $fileTo) : bool
+    {
+        return File::copy($fileFrom, $fileTo);
+    }
+}

--- a/src/Console/CopyAssetsToPublicFolder.php
+++ b/src/Console/CopyAssetsToPublicFolder.php
@@ -10,7 +10,7 @@ class CopyAssetsToPublicFolder extends Command
     /**
      * @var string
      */
-    protected $signature = 'tall-toast:assets';
+    protected $signature = 'tall-toasts:assets';
 
     /**
      * @var string
@@ -24,23 +24,28 @@ class CopyAssetsToPublicFolder extends Command
      */
     public function handle() : int
     {
-        $vendorToastFile = __DIR__ . '/../../dist/js/tall-toasts.js';
-        $vendorToastMap = __DIR__ . '/../../dist/js/tall-toasts.js.map';
+        $vendorFolder = __DIR__ . '/../../dist/js';
 
-        $publicToastFile = public_path('/toast/tall-toasts.js');
-        $publicToastMap = public_path('/toast/tall-toasts.js.map');
+        $vendorToastFile = $vendorFolder . '/tall-toasts.js';
 
-        if($this->fileExists(public_path('toast/tall-toasts.js'))){
+
+        $publicFolder = public_path('/toast');
+
+        $publicToastFile = $publicFolder . '/tall-toasts.js';
+
+        if($this->fileExists($publicToastFile)){
             if($this->fileIsSame($vendorToastFile, $publicToastFile)){
                 $this->info('Tall Toasts Javascript does not need to be copied.');
                 return Command::SUCCESS;
-            }
+            };
+        }
+        else {
+            File::makeDirectory($publicFolder);
         }
 
-        $this->copyFile($vendorToastFile, $publicToastFile);
-        $this->copyFile($vendorToastMap, $publicToastMap);
+        $this->copyDir($vendorFolder, $publicFolder);
 
-        $this->info('Copied Tall Toasts assets to public/toast/');
+        $this->info('Copied Tall Toasts assets to ' . $publicFolder);
 
         return Command::SUCCESS;
     }
@@ -72,8 +77,8 @@ class CopyAssetsToPublicFolder extends Command
      * @param string $fileTo
      * @return bool
      */
-    private function copyFile(string $fileFrom, string $fileTo) : bool
+    private function copyDir(string $fromFolder, string $toFolder) : bool
     {
-        return File::copy($fileFrom, $fileTo);
+        return File::copyDirectory($fromFolder, $toFolder);
     }
 }

--- a/src/Console/CopyAssetsToPublicFolder.php
+++ b/src/Console/CopyAssetsToPublicFolder.php
@@ -22,7 +22,7 @@ class CopyAssetsToPublicFolder extends Command
      *
      * @return int
      */
-    public function handle() : int
+    public function handle(): int
     {
         $vendorFolder = __DIR__ . '/../../dist/js';
 
@@ -33,13 +33,13 @@ class CopyAssetsToPublicFolder extends Command
 
         $publicToastFile = $publicFolder . '/tall-toasts.js';
 
-        if($this->fileExists($publicToastFile)){
-            if($this->fileIsSame($vendorToastFile, $publicToastFile)){
+        if ($this->fileExists($publicToastFile)) {
+            if ($this->fileIsSame($vendorToastFile, $publicToastFile)) {
                 $this->info('Tall Toasts Javascript does not need to be copied.');
+
                 return Command::SUCCESS;
             };
-        }
-        else {
+        } else {
             File::makeDirectory($publicFolder);
         }
 
@@ -55,7 +55,7 @@ class CopyAssetsToPublicFolder extends Command
      * @param string $fileName
      * @return bool
      */
-    private function fileExists(string $fileName) : bool
+    private function fileExists(string $fileName): bool
     {
         return File::exists($fileName);
     }
@@ -66,7 +66,7 @@ class CopyAssetsToPublicFolder extends Command
      * @param string $publicFile
      * @return bool
      */
-    private function fileIsSame(string $originalFile, string $publicFile) : bool
+    private function fileIsSame(string $originalFile, string $publicFile): bool
     {
         return file_get_contents($originalFile) === file_get_contents($publicFile);
     }
@@ -77,7 +77,7 @@ class CopyAssetsToPublicFolder extends Command
      * @param string $fileTo
      * @return bool
      */
-    private function copyDir(string $fromFolder, string $toFolder) : bool
+    private function copyDir(string $fromFolder, string $toFolder): bool
     {
         return File::copyDirectory($fromFolder, $toFolder);
     }

--- a/src/ToastServiceProvider.php
+++ b/src/ToastServiceProvider.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Route as RouteFacade;
 use Livewire\Livewire;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
+use Usernotnull\Toast\Console\CopyAssetsToPublicFolder;
 use Usernotnull\Toast\Controllers\JavaScriptAssets;
 use Usernotnull\Toast\Http\Livewire\ToastComponent;
 
@@ -19,6 +20,7 @@ class ToastServiceProvider extends PackageServiceProvider
     {
         $package->name('tall-toasts')
             ->hasConfigFile()
+            ->hasCommand(CopyAssetsToPublicFolder::class)
             ->hasViews();
     }
 

--- a/tests/Unit/CopyAssetsCommandTest.php
+++ b/tests/Unit/CopyAssetsCommandTest.php
@@ -1,0 +1,12 @@
+<?php
+
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+
+it('can copy assets to public folder', function () {
+    expect(File::exists(public_path('/toast/tall-toasts.js')))->toBeFalse();
+
+    Artisan::call('tall-toasts:assets');
+
+    expect(File::exists(public_path('/toast/tall-toasts.js')))->toBeTrue();
+});


### PR DESCRIPTION
## PR Title

Adds a command to help with #31 

### Description

I have added a `tall-toasts:assets` Artisan command. This command allows users to copy the tall toasts' Javascript assets to `public/toast/` if needed.  This can be utilized in composer's `post-dump-autoload` script.

### Related Issue

This is related to issue #31 

### Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
