### PR TITLE
Refactor Toast methods to allow nullable title parameter

### DIFF
--- a/src/Toast.php
+++ b/src/Toast.php
@@ -8,12 +8,12 @@ use function is_string;
 
 class Toast
 {
-    public function danger(string $message, string $title = null): Notification
+    public function danger(string $message, ?string $title = null): Notification
     {
         return new Notification($message, $title, NotificationType::$danger);
     }
 
-    public function debug(mixed $message, string $title = null): Notification
+    public function debug(mixed $message, ?string $title = null): Notification
     {
         if (! is_string($message)) {
             $message = json_encode($message, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT);
@@ -22,17 +22,17 @@ class Toast
         return new Notification($message, $title, NotificationType::$debug);
     }
 
-    public function info(string $message, string $title = null): Notification
+    public function info(string $message, ?string $title = null): Notification
     {
         return new Notification($message, $title, NotificationType::$info);
     }
 
-    public function success(string $message, string $title = null): Notification
+    public function success(string $message, ?string $title = null): Notification
     {
         return new Notification($message, $title, NotificationType::$success);
     }
 
-    public function warning(string $message, string $title = null): Notification
+    public function warning(string $message, ?string $title = null): Notification
     {
         return new Notification($message, $title, NotificationType::$warning);
     }


### PR DESCRIPTION
This pull request updates the `Toast` class to improve type safety and consistency for the optional `title` parameter in its notification methods. All relevant methods now explicitly declare the `title` parameter as nullable, aligning with modern PHP best practices.

Type consistency improvements:

* Changed the `title` parameter type from `string $title = null` to `?string $title = null` in the following methods: `danger`, `debug`, `info`, `success`, and `warning`. This ensures proper handling of cases where no title is provided. [[1]](diffhunk://#diff-57cece93a81a110a2c397b233e7a515b85e973ab403bd2cc115aa936fa4c44b3L11-R16) [[2]](diffhunk://#diff-57cece93a81a110a2c397b233e7a515b85e973ab403bd2cc115aa936fa4c44b3L25-R35)