### PR TITLE
Add support for Laravel 13 and Livewire 4

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -23,21 +23,16 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: ['8.1', '8.2']
-        laravel: ['11.0', '12.0', ^10.0]
+        php: ['8.2', '8.3', '8.4']
+        laravel: ['11.0', '12.0', '13.0']
         dependency-version: [prefer-stable]
         include:
-          - laravel: ^10.0
-            testbench: ^8.1
           - laravel: '11.0'
             testbench: ^9.0
           - laravel: '12.0'
             testbench: ^10.0
-        exclude:
-          - laravel: '11.0'
-            php: '8.1'
-          - laravel: '12.0'
-            php: '8.1'
+          - laravel: '13.0'
+            testbench: ^11.0
 
 
     steps:
@@ -95,18 +90,13 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: ['8.1', '8.2']
-        laravel: ['11.0', '12.0', ^10.0]
+        php: ['8.2', '8.3', '8.4']
+        laravel: ['11.0', '12.0', '13.0']
         dependency-version: [prefer-stable]
         include:
-          - laravel: ^10.0
           - laravel: '11.0'
           - laravel: '12.0'
-        exclude:
-          - laravel: '11.0'
-            php: '8.1'
-          - laravel: '12.0'
-            php: '8.1'
+          - laravel: '13.0'
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 
@@ -145,7 +135,7 @@ jobs:
 
 
       - name: Upload Coverage
-        if: "github.ref == 'refs/heads/main' && matrix.php == '8.1' && matrix.laravel == '10.*' && matrix.os == 'ubuntu-latest' && matrix.dependency-version == 'prefer-stable'"
+        if: "github.ref == 'refs/heads/main' && matrix.php == '8.2' && matrix.laravel == '11.0' && matrix.os == 'ubuntu-latest' && matrix.dependency-version == 'prefer-stable'"
         uses: codacy/codacy-coverage-reporter-action@v1.3
         with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
@@ -153,7 +143,7 @@ jobs:
 
 
       - name: Upload coverage to Codecov
-        if: "github.ref == 'refs/heads/main' && matrix.php == '8.1' && matrix.laravel == '10.*' && matrix.os == 'ubuntu-latest' && matrix.dependency-version == 'prefer-stable'"
+        if: "github.ref == 'refs/heads/main' && matrix.php == '8.2' && matrix.laravel == '11.0' && matrix.os == 'ubuntu-latest' && matrix.dependency-version == 'prefer-stable'"
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/composer.json
+++ b/composer.json
@@ -25,22 +25,21 @@
         }
     ],
     "require": {
-        "php": "^8.0|^8.1",
-        "illuminate/contracts": "^8.15 || 9.0 - 9.34 || ^9.36 || ^10.0|^11.0|^12.0",
+        "php": "^8.2",
+        "illuminate/contracts": "^8.15 || 9.0 - 9.34 || ^9.36 || ^10.0|^11.0|^12.0|^13.0",
         "spatie/laravel-package-tools": "^1.19",
-        "livewire/livewire": "^v3"
+        "livewire/livewire": "^v3|^4"
     },
     "require-dev": {
-        "pestphp/pest": "^1.23.1|^3.7",
-        "nunomaduro/larastan": "^2.9",
+        "pestphp/pest": "^3.7|^4.0",
+        "larastan/larastan": "^3.0",
         "laravel/pint": "^1.21",
-        "nunomaduro/collision": "^6.4.0",
-        "orchestra/testbench": "^8.23.2|^10.0",
-        "pestphp/pest-plugin-laravel": "^1.4.0|^3.1",
+        "nunomaduro/collision": "^8.0",
+        "orchestra/testbench": "^9.0|^10.0|^11.0",
+        "pestphp/pest-plugin-laravel": "^3.1|^4.0",
         "friendsofphp/php-cs-fixer": "^v3.71",
-        "pestphp/pest-plugin-parallel": "^1.2",
         "phpmd/phpmd": "^2.15",
-        "squizlabs/php_codesniffer": "^3.11",
+        "squizlabs/php_codesniffer": "^3.11|^4.0",
         "vimeo/psalm": "^5.26.1|^6.6"
     },
     "autoload": {

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -10,14 +10,11 @@ uses(TestCase::class)->in('Feature', 'Unit');
 
 function createFakeComponent(): void
 {
-    new class () extends Component {
+    $component = new class () extends Component {
         use WireToast;
-
-        public function __construct()
-        {
-            $this->dehydrate(new \Illuminate\Http\Response(request()));
-        }
     };
+
+    $component->renderedWireToast();
 }
 
 function setEnvironment(string $environment = 'testing'): void


### PR DESCRIPTION
## PR Title

Add support for Laravel 13 and Livewire 4

### Description

Updates the package to support Laravel 13 and Livewire 4 while maintaining backward compatibility with Laravel 11, 12 and Livewire 3.

**Changes:**
- **CI workflow:** Updated test matrix to cover PHP 8.2/8.3/8.4, Laravel 11/12/13, and the correct Orchestra Testbench mappings (`^9.0` for L11, `^10.0` for L12, `^11.0` for L13). Dropped PHP 8.1 and Laravel 10 from the matrix since the package requires PHP `^8.2`.
- **Test fix:** Updated `createFakeComponent()` in `tests/Pest.php` - the helper was calling `$this->dehydrate()` directly on a Component instance, which no longer exists as a method on the Component class in Livewire 4. Replaced with a direct call to `renderedWireToast()`, which is the actual trait method under test.

No changes to package source code were needed - the existing Livewire APIs (`dehydrate()` lifecycle hook, `$this->dispatch()`, `$wire.$entangle()`) are all compatible with both Livewire 3 and 4.

### Related Issue

N/A

### Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.